### PR TITLE
get dns nameservers from termux instead of system

### DIFF
--- a/TermuxAlpine.sh
+++ b/TermuxAlpine.sh
@@ -142,10 +142,7 @@ unset LD_PRELOAD
 # thnx to @j16180339887 for DNS picker
 addresolvconf ()
 {
-  android=\$(getprop ro.build.version.release)
-  if [ \${android%%.*} -lt 8 ]; then
-  [ \$(command -v getprop) ] && getprop | sed -n -e 's/^\[net\.dns.\]: \[\(.*\)\]/\1/p' | sed '/^\s*$/d' | sed 's/^/nameserver /' > \${PREFIX}/share/TermuxAlpine/etc/resolv.conf
-  fi
+  cp \${PREFIX}/etc/resolv.conf \${PREFIX}/share/TermuxAlpine/etc/resolv.conf
 }
 addresolvconf
 exec proot --link2symlink -0 -r \${PREFIX}/share/TermuxAlpine/ -b /dev/ -b /sys/ -b /proc/ -b /sdcard -b /storage -b \$HOME -w /home /usr/bin/env HOME=/root PREFIX=/usr SHELL=/bin/sh TERM="\$TERM" LANG=\$LANG PATH=/bin:/usr/bin:/sbin:/usr/sbin /bin/sh --login


### PR DESCRIPTION
On some systems, like my (android 5.1) `getprop` return is broken nameservers (10.10.30.150). With this commit I'm and other users can use resolv.conf from termux.