### PR TITLE
ensure that the HOME variable and -w (working directory) match

### DIFF
--- a/TermuxAlpine.sh
+++ b/TermuxAlpine.sh
@@ -148,7 +148,7 @@ addresolvconf ()
   fi
 }
 addresolvconf
-exec proot --link2symlink -0 -r \${PREFIX}/share/TermuxAlpine/ -b /dev/ -b /sys/ -b /proc/ -b /sdcard -b /storage -b \$HOME -w /home /usr/bin/env TMPDIR=/tmp HOME=/root PREFIX=/usr SHELL=/bin/sh TERM="\$TERM" LANG=\$LANG PATH=/bin:/usr/bin:/sbin:/usr/sbin /bin/sh --login
+exec proot --link2symlink -0 -r \${PREFIX}/share/TermuxAlpine/ -b /dev/ -b /sys/ -b /proc/ -b /sdcard -b /storage -b \$HOME -w /home /usr/bin/env TMPDIR=/tmp HOME=/home PREFIX=/usr SHELL=/bin/sh TERM="\$TERM" LANG=\$LANG PATH=/bin:/usr/bin:/sbin:/usr/sbin /bin/sh --login
 EOM
 
 	chmod 700 $bin


### PR DESCRIPTION
Each time I run `startalpine` I am loaded into the `/home` directory, but `$HOME` is set to `/root`. This PR corrects the `HOME` variable.

Alternatively, we could set `-w /root` in the same command if we prefer to use /root at the home dir.